### PR TITLE
Set author of library to "LibrePCB"

### DIFF
--- a/library.lp
+++ b/library.lp
@@ -2,7 +2,7 @@
  (name "Arduino")
  (description "Arduino boards.")
  (keywords "")
- (author "Danilo Bargen")
+ (author "LibrePCB")
  (version "0.1")
  (created 2018-11-17T11:44:39Z)
  (deprecated false)


### PR DESCRIPTION
All of our other libraries have "LibrePCB" as author, thus it looks a bit strange to have one library with a different author ;) For library *elements* this is fine, but the library author is shown directly in the library manager, even before downloading it.

@dbrgn I hope this is OK for you? :smiley: 